### PR TITLE
Remove unnecessary copyrightYearBasis setting

### DIFF
--- a/classes/components/forms/context/LicenseForm.inc.php
+++ b/classes/components/forms/context/LicenseForm.inc.php
@@ -13,29 +13,5 @@
  */
 namespace APP\components\forms\context;
 use \PKP\components\forms\context\PKPLicenseForm;
-use \PKP\components\forms\FieldOptions;
 
-class LicenseForm extends PKPLicenseForm {
-	/** @copydoc FormComponent::$id */
-	public $id = FORM_LICENSE;
-
-	/** @copydoc FormComponent::$method */
-	public $method = 'PUT';
-
-	/**
-	 * @copydoc PKPLicenseForm::__construct()
-	 */
-	public function __construct($action, $locales, $context) {
-		parent::__construct($action, $locales, $context);
-
-		$this->addField(new FieldOptions('copyrightYearBasis', [
-				'label' => __('submission.copyrightYear'),
-				'description' => __('manager.distribution.copyrightYearBasis.description'),
-				'type' => 'radio',
-				'options' => [
-					['value' => 'submission', 'label' => __('manager.distribution.copyrightYearBasis.submission')],
-				],
-				'value' => $context->getData('copyrightYearBasis'),
-			]), [FIELD_POSITION_AFTER, 'licenseUrl']);
-	}
-}
+class LicenseForm extends PKPLicenseForm { }

--- a/classes/submission/Submission.inc.php
+++ b/classes/submission/Submission.inc.php
@@ -68,18 +68,12 @@ class Submission extends PKPSubmission {
 				// Default copyright year to current year
 				$fieldValue = date('Y');
 
-				// Override based on context settings
+				// Use preprint publish date of current publication
 				if (!$publication) {
 					$publication = $this->getCurrentPublication();
 				}
 				if ($publication) {
-					switch($context->getData('copyrightYearBasis')) {
-						case 'submission':
-							// override to the submission's year if published as you go
-							$fieldValue = date('Y', strtotime($publication->getData('datePublished')));
-							break;
-						default: assert(false);
-					}
+					$fieldValue = date('Y', strtotime($publication->getData('datePublished')));
 				}
 				break;
 			default: assert(false);


### PR DESCRIPTION
OPS had a setting for copyrightYearBasis, but the only possible option here is the submission publishdate, so no setting needed.