### PR TITLE
[OPS][3.2.1] #5961 Use the Schema::get:: hook for registering PubObjectsExportPlugin additional schema fields

### DIFF
--- a/classes/plugins/PubObjectsExportPlugin.inc.php
+++ b/classes/plugins/PubObjectsExportPlugin.inc.php
@@ -59,14 +59,7 @@ abstract class PubObjectsExportPlugin extends ImportExportPlugin {
 		HookRegistry::register('AcronPlugin::parseCronTab', array($this, 'callbackParseCronTab'));
 		foreach ($this->_getDAOs() as $dao) {
 			if ($dao instanceof SchemaDAO) {
-				$schema = Services::get('schema')->get($dao->schemaName);
-				foreach ($this->_getObjectAdditionalSettings() as $fieldName) {
-					$schema->properties->{$fieldName} = (object) [
-						'type' => 'string',
-						'apiSummary' => true,
-						'validation' => ['nullable'],
-					];
-				}
+				HookRegistry::register('Schema::get::' . $dao->schemaName, array($this, 'addToSchema'));
 			} else {
 				HookRegistry::register(strtolower_codesafe(get_class($dao)) . '::getAdditionalFieldNames', array(&$this, 'getAdditionalFieldNames'));
 			}
@@ -408,6 +401,28 @@ abstract class PubObjectsExportPlugin extends ImportExportPlugin {
 		foreach ($this->_getObjectAdditionalSettings() as $fieldName) {
 			$additionalFields[] = $fieldName;
 		}
+		
+		return false;
+	}
+
+	/**
+	 * Add properties for this type of public identifier to the entity's list for
+	 * storage in the database.
+	 * This is used for SchemaDAO-backed entities only.
+	 * @see PKPPubIdPlugin::getAdditionalFieldNames()
+	 * @param $hookName string `Schema::get::publication`
+	 * @param $params array
+	 */
+	public function addToSchema($hookName, $params) {
+		$schema =& $params[0];
+		foreach ($this->_getObjectAdditionalSettings() as $fieldName) {
+			$schema->properties->{$fieldName} = (object) [
+				'type' => 'string',
+				'apiSummary' => true,
+				'validation' => ['nullable'],
+			];
+		}
+
 		return false;
 	}
 


### PR DESCRIPTION
(cherry picked from commit ee44874fcc06e6545db9839b703b03552b87b60f)