### PR TITLE
Fixes getCitationData method from DOI plugin

### DIFF
--- a/plugins/pubIds/doi/DOIPubIdPlugin.inc.php
+++ b/plugins/pubIds/doi/DOIPubIdPlugin.inc.php
@@ -223,10 +223,9 @@ class DOIPubIdPlugin extends PubIdPlugin {
 	public function getCitationData($hookname, $args) {
 		$citationData = $args[0];
 		$article = $args[2];
-		#$issue = $args[3];
-		$journal = $args[4];
+		$pubId = $this->getPubId($article);
 
-		if (!$this->getPubId($article)) {
+		if (!$pubId) {
 			return;
 		}
 


### PR DESCRIPTION
This modification is part of the effort to add support for OPS to the Citation Style Language plugin, which originates from the issue https://github.com/pkp/pkp-lib/issues/6700 .