### PR TITLE
Add missing composer install instruction for citationStyleLanguage

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Checkout submodules and copy default configuration :
 Install or update dependencies via Composer (https://getcomposer.org/):
 
     composer --working-dir=lib/pkp install
+    composer --working-dir=plugins/generic/citationStyleLanguage install
 
 Install or update dependencies via [NPM](https://www.npmjs.com/):
 


### PR DESCRIPTION
For the main branch, it is required to run composer install for the plugins/generic/citationStyleLanguage to install the software which is missing in the README file .