### PR TITLE
pkp/pkp-lib#4240 Submodule Update ##touhidurabir/i4240_fix_main##

### DIFF
--- a/config.TEMPLATE.inc.php
+++ b/config.TEMPLATE.inc.php
@@ -128,6 +128,12 @@ enable_beacon = On
 ; as separate Privacy Statements for each server.
 sitewide_privacy_statement = Off
 
+; The number of days a new user has to validate their account
+; A new user account will be expired and removed if this many days have passed since the user registered
+; their account, and they have not validated their account or logged in. If the user_validation_period is set to
+; 0, unvalidated accounts will never be removed. Use this setting to automatically remove bot registrations.
+user_validation_period = 28
+
 
 ;;;;;;;;;;;;;;;;;;;;;
 ; Database Settings ;

--- a/registry/scheduledTasks.xml
+++ b/registry/scheduledTasks.xml
@@ -31,4 +31,8 @@
 		<descr>Send automated statistics reports to server managers and editors.</descr>
 		<frequency day="1"/>
 	</task>
+	<task class="lib.pkp.classes.task.RemoveUnvalidatedExpiredUsers">
+		<descr>Automatically remove unvalidated and expired users.</descr>
+		<frequency day="1"/>
+	</task>
 </scheduled_tasks>


### PR DESCRIPTION
This PR aims to resolve the issue https://github.com/pkp/pkp-lib/issues/4240 by adding the feature that will allow automatic removal of unvalidated expired users . The removal process as follows :

- User has not validated
- User has never logged in since registration
- the difference between registration and task running has passed what is set for validation_timeout in the config file

Also the removal process needed to be initiated from the `config` file as setting defined .