### PR TITLE
pkp/pkp-lib#8125 add missing method getCanonicalUrl in Usage event

### DIFF
--- a/classes/observers/events/Usage.php
+++ b/classes/observers/events/Usage.php
@@ -30,4 +30,14 @@ class Usage
     {
         $this->traitConstruct($assocType, $context, $submission, $publicationFormat, $submissionFile);
     }
+
+    /**
+     * Get the canonical URL for the usage object
+     *
+     * @throws Exception
+     */
+    protected function getCanonicalUrl(): string
+    {
+        return $this->getTraitCanonicalUrl();
+    }
 }


### PR DESCRIPTION
s. https://github.com/pkp/pkp-lib/issues/8125