### PR TITLE
pkp/pkp-lib#5196 CSS Pseudo selectors creating a duplicated link announcement on screenreaders

### DIFF
--- a/plugins/themes/default/styles/objects/preprint_details.less
+++ b/plugins/themes/default/styles/objects/preprint_details.less
@@ -121,9 +121,12 @@
 
 	.galleys_links {
 		&:extend(.pkp_unstyled_list);
-
+		display: flex;
+		flex-flow: row nowrap;
+		justify-content: start;
+		
 		li {
-			display: inline-block;
+			margin-inline-end: 1rem;
 		}
 	}
 

--- a/plugins/themes/default/styles/objects/preprint_summary.less
+++ b/plugins/themes/default/styles/objects/preprint_summary.less
@@ -95,13 +95,15 @@
 	.galleys_links {
 		&:extend(.pkp_unstyled_list);
 		margin-top: @base;
+		display: flex;
+		flex-flow: row nowrap;
+		justify-content: start;
 
 		li {
-			display: inline-block;
-			margin-right: 0.5em;
+			margin-inline-end: 1rem;
 
 			&:last-child {
-				margin-right: 0;
+				margin-inline-end: 0;
 			}
 		}
 	}


### PR DESCRIPTION
Adding flexbox to `galley_links` class of `UL` element and adjusting margin of `LI` elements replacing `margin` parameter by `margin-inline-end`.