### PR TITLE
pkp/pkp-lib#8327 Locale regex validation rules update to support 2 character locale code

### DIFF
--- a/schemas/galley.json
+++ b/schemas/galley.json
@@ -47,7 +47,7 @@
 			"description": "The primary locale of this galley.",
 			"apiSummary": true,
 			"validation": [
-				"regex:/^[a-z]{2}_[A-Z]{2}(@[a-z]{0,})?$/"
+				"regex:/^([a-z]{2})((_[A-Z]{2})?)(@[a-z]{0,})?$/"
 			]
 		},
 		"label": {


### PR DESCRIPTION
This PR aims to solve https://github.com/pkp/pkp-lib/issues/8327