### PR TITLE
Submission and metadata languages separated from UI and form languages

### DIFF
--- a/classes/migration/install/OPSMigration.php
+++ b/classes/migration/install/OPSMigration.php
@@ -58,7 +58,7 @@ class OPSMigration extends \PKP\migration\Migration
             $table->foreign('section_id')->references('section_id')->on('sections')->onDelete('cascade');
             $table->index(['section_id'], 'section_settings_section_id');
 
-            $table->string('locale', 14)->default('');
+            $table->string('locale', 28)->default('');
             $table->string('setting_name', 255);
             $table->text('setting_value')->nullable();
 
@@ -110,7 +110,7 @@ class OPSMigration extends \PKP\migration\Migration
         Schema::create('publication_galleys', function (Blueprint $table) {
             $table->comment('Publication galleys are representations of publications in a particular format, such as a PDF file.');
             $table->bigInteger('galley_id')->autoIncrement();
-            $table->string('locale', 14)->nullable();
+            $table->string('locale', 28)->nullable();
 
             $table->bigInteger('publication_id');
             $table->foreign('publication_id', 'publication_galleys_publication_id')->references('publication_id')->on('publications')->onDelete('cascade');
@@ -143,7 +143,7 @@ class OPSMigration extends \PKP\migration\Migration
             $table->foreign('galley_id')->references('galley_id')->on('publication_galleys');
             $table->index(['galley_id'], 'publication_galley_settings_galley_id');
 
-            $table->string('locale', 14)->default('');
+            $table->string('locale', 28)->default('');
             $table->string('setting_name', 255);
             $table->text('setting_value')->nullable();
 

--- a/classes/migration/install/ServersMigration.php
+++ b/classes/migration/install/ServersMigration.php
@@ -30,7 +30,7 @@ class ServersMigration extends \PKP\migration\Migration
             $table->bigInteger('server_id')->autoIncrement();
             $table->string('path', 32);
             $table->float('seq', 8, 2)->default(0)->comment('Used to order lists of servers');
-            $table->string('primary_locale', 14);
+            $table->string('primary_locale', 28);
             $table->tinyInteger('enabled')->default(1)->comment('Controls whether or not the server is considered "live" and will appear on the website. (Note that disabled servers may still be accessible, but only if the user knows the URL.)');
             $table->unique(['path'], 'servers_path');
         });
@@ -44,7 +44,7 @@ class ServersMigration extends \PKP\migration\Migration
             $table->foreign('server_id', 'server_settings_server_id')->references('server_id')->on('servers')->onDelete('cascade');
             $table->index(['server_id'], 'server_settings_server_id');
 
-            $table->string('locale', 14)->default('');
+            $table->string('locale', 28)->default('');
             $table->string('setting_name', 255);
             $table->text('setting_value')->nullable();
 

--- a/classes/migration/upgrade/v3_5_0/I9425_SeparateUIAndSubmissionLocales.php
+++ b/classes/migration/upgrade/v3_5_0/I9425_SeparateUIAndSubmissionLocales.php
@@ -1,0 +1,31 @@
+<?php
+
+/**
+ * @file classes/migration/upgrade/v3_5_0/I9425_SeparateUIAndSubmissionLocales.php
+ *
+ * Copyright (c) 2024 Simon Fraser University
+ * Copyright (c) 2024 John Willinsky
+ * Distributed under the GNU GPL v3. For full terms see the file docs/COPYING.
+ *
+ * @class I9425_SeparateUIAndSubmissionLocales
+ *
+ * @brief pkp/pkp-lib#9425 Make submission language selection and metadata forms independent from website language settings
+ */
+
+namespace APP\migration\upgrade\v3_5_0;
+
+class I9425_SeparateUIAndSubmissionLocales extends \PKP\migration\upgrade\v3_5_0\I9425_SeparateUIAndSubmissionLocales
+{
+    protected function getContextTable(): string
+    {
+        return 'servers';
+    }
+    protected function getContextSettingsTable(): string
+    {
+        return 'server_settings';
+    }
+    protected function getContextIdColumn(): string
+    {
+        return 'server_id';
+    }
+}

--- a/classes/publication/Repository.php
+++ b/classes/publication/Repository.php
@@ -41,9 +41,7 @@ class Repository extends \PKP\publication\Repository
     public function validate($publication, array $props, Submission $submission, Context $context): array
     {
         $errors = parent::validate($publication, $props, $submission, $context);
-
-        $allowedLocales = $context->getSupportedSubmissionLocales();
-        $primaryLocale = $submission->getData('locale');
+        $submissionLocale = $submission->getData('locale');
 
         // Ensure that the specified section exists
         $section = null;
@@ -63,21 +61,22 @@ class Repository extends \PKP\publication\Repository
         if ($section && !$submission->getData('submissionProgress')) {
             // Require abstracts if the section requires them
             if (is_null($publication) && !$section->getData('abstractsNotRequired') && empty($props['abstract'])) {
-                $errors['abstract'][$primaryLocale] = [__('author.submit.form.abstractRequired')];
+                $errors['abstract'][$submissionLocale] = [__('author.submit.form.abstractRequired')];
             }
 
             if (isset($props['abstract']) && empty($errors['abstract'])) {
                 // Require abstracts in the primary language if the section requires them
                 if (!$section->getData('abstractsNotRequired')) {
-                    if (empty($props['abstract'][$primaryLocale])) {
+                    if (empty($props['abstract'][$submissionLocale])) {
                         if (!isset($errors['abstract'])) {
                             $errors['abstract'] = [];
                         };
-                        $errors['abstract'][$primaryLocale] = [__('author.submit.form.abstractRequired')];
+                        $errors['abstract'][$submissionLocale] = [__('author.submit.form.abstractRequired')];
                     }
                 }
 
                 // Check the word count on abstracts
+                $allowedLocales = $submission->getPublicationLanguages($context->getSupportedSubmissionMetadataLocales());
                 foreach ($allowedLocales as $localeKey) {
                     if (empty($props['abstract'][$localeKey])) {
                         continue;

--- a/classes/publication/maps/Schema.php
+++ b/classes/publication/maps/Schema.php
@@ -49,7 +49,9 @@ class Schema extends \PKP\publication\maps\Schema
             );
         }
 
-        $output = $this->schemaService->addMissingMultilingualValues(PKPSchemaService::SCHEMA_PUBLICATION, $output, $this->context->getSupportedSubmissionLocales());
+        $locales = $this->submission->getPublicationLanguages($this->context->getSupportedSubmissionMetadataLocales());
+
+        $output = $this->schemaService->addMissingMultilingualValues(PKPSchemaService::SCHEMA_PUBLICATION, $output, $locales);
 
         ksort($output);
 

--- a/classes/submission/Repository.php
+++ b/classes/submission/Repository.php
@@ -50,7 +50,8 @@ class Repository extends \PKP\submission\Repository
             $abstracts = $publication->getData('abstract');
             if ($abstracts) {
                 $abstractErrors = [];
-                foreach ($context->getSupportedSubmissionLocales() as $localeKey) {
+                $allowedLocales = $submission->getPublicationLanguages($context->getSupportedSubmissionMetadataLocales());
+                foreach ($allowedLocales as $localeKey) {
                     $abstract = $publication->getData('abstract', $localeKey);
                     $wordCount = $abstract ? PKPString::getWordCount($abstract) : 0;
                     if ($wordCount > $section->getAbstractWordCount()) {

--- a/classes/submission/maps/Schema.php
+++ b/classes/submission/maps/Schema.php
@@ -35,7 +35,13 @@ class Schema extends \PKP\submission\maps\Schema
             );
         }
 
-        $output = $this->schemaService->addMissingMultilingualValues($this->schemaService::SCHEMA_SUBMISSION, $output, $this->context->getSupportedSubmissionLocales());
+        $locales = $this->context->getSupportedSubmissionMetaDataLocales();
+
+        if (!in_array($submissionLocale = $submission->getData('locale'), $locales)) {
+            $locales[] = $submissionLocale;
+        }
+
+        $output = $this->schemaService->addMissingMultilingualValues($this->schemaService::SCHEMA_SUBMISSION, $output, $locales);
 
         ksort($output);
 

--- a/cypress/tests/data/10-ApplicationSetup/20-CreateContext.cy.js
+++ b/cypress/tests/data/10-ApplicationSetup/20-CreateContext.cy.js
@@ -70,8 +70,13 @@ describe('Data suite tests', function() {
 		cy.get('#appearance [role="status"]').contains('Saved');
 
 		cy.get('button[id="languages-button"]').click();
-		cy.get('input[id^=select-cell-fr_CA-submissionLocale]').click();
-		cy.contains('Locale settings saved.');
+		cy.get('input[id^="select-cell-fr_CA-formLocale"]').click();
+		cy.get('a[id^=component-grid-settings-languages-submissionlanguagegrid-addLanguageModal-button]').click();
+		cy.get('#locale-fr_CA').should('exist').click();
+		cy.get('#addLanguageForm button[name="submitFormButton"]').click();
+		cy.contains('Submission locales updated.').should('exist');
+		cy.get('input[id^="select-cell-fr_CA-submissionLocale"]').click();
+		cy.get('input[id^="select-cell-fr_CA-submissionMetadataLocale"]').should('be.checked');
 
 		cy.get('button[id="indexing-button"]').click();
 		cy.get('input[name="searchDescription-en"]').type(Cypress.env('contextDescriptions')['en'], {delay: 0});

--- a/cypress/tests/data/60-content/CkwantesSubmission.cy.js
+++ b/cypress/tests/data/60-content/CkwantesSubmission.cy.js
@@ -194,7 +194,7 @@ describe('Data suite: Ckwantes', function() {
 			.find('h4').contains('Keywords').siblings('.submissionWizard__reviewPanel__item__value').contains('employees, survey')
 			.parents('.submissionWizard__reviewPanel')
 			.find('h4').contains('Abstract').siblings('.submissionWizard__reviewPanel__item__value').contains(submission.abstract);
-		cy.get('h3').contains('Details (French)')
+		cy.get('h3').contains('Details (French (Canada))')
 			.parents('.submissionWizard__reviewPanel')
 			.find('h4').contains('Title').siblings('.submissionWizard__reviewPanel__item__value').contains('None provided')
 			.parents('.submissionWizard__reviewPanel')
@@ -202,7 +202,7 @@ describe('Data suite: Ckwantes', function() {
 			.parents('.submissionWizard__reviewPanel')
 			.find('h4').contains('Abstract').siblings('.submissionWizard__reviewPanel__item__value').contains('None provided');
 		cy.get('h3').contains('For Readers (English)')
-		cy.get('h3').contains('For Readers (French)')
+		cy.get('h3').contains('For Readers (French (Canada))')
 
 		// Save for later
 		cy.get('button').contains('Save for Later').click();

--- a/dbscripts/xml/upgrade.xml
+++ b/dbscripts/xml/upgrade.xml
@@ -104,6 +104,7 @@
 		<migration class="PKP\migration\upgrade\v3_5_0\I9262_Highlights"/>
 		<migration class="PKP\migration\upgrade\v3_5_0\I9462_UserUserGroups"/>
 		<migration class="PKP\migration\upgrade\v3_5_0\I9552_UserGroupsMasthead"/>
+		<migration class="APP\migration\upgrade\v3_5_0\I9425_SeparateUIAndSubmissionLocales"/>
 	</upgrade>
 
 	<!-- update plugin configuration - should be done as the final upgrade task -->

--- a/pages/submission/SubmissionHandler.php
+++ b/pages/submission/SubmissionHandler.php
@@ -108,7 +108,7 @@ class SubmissionHandler extends PKPSubmissionHandler
                 'submission.wizard.submittingToSectionInLanguage',
                 [
                     'section' => $section->getLocalizedTitle(),
-                    'language' => Locale::getMetadata($submission->getData('locale'))->getDisplayName(),
+                    'language' => Locale::getSubmissionLocaleDisplayNames([$submission->getData('locale')])[$submission->getData('locale')],
                 ]
             );
         } elseif ($sectionCount) {
@@ -122,7 +122,7 @@ class SubmissionHandler extends PKPSubmissionHandler
             return __(
                 'submission.wizard.submittingInLanguage',
                 [
-                    'language' => Locale::getMetadata($submission->getData('locale'))->getDisplayName(),
+                    'language' => Locale::getSubmissionLocaleDisplayNames([$submission->getData('locale')])[$submission->getData('locale')],
                 ]
             );
         }
@@ -176,7 +176,7 @@ class SubmissionHandler extends PKPSubmissionHandler
 
         Hook::add('Template::SubmissionWizard::Section', function (string $hookName, array $params) {
             $templateMgr = $params[1]; /** @var TemplateManager $templateMgr */
-            $output = & $params[2]; /** @var string $step */
+            $output = &$params[2]; /** @var string $step */
 
             $output .= sprintf(
                 '<template v-else-if="section.id === \'' . self::GALLEYS_SECTION_ID . '\'">%s</template>',
@@ -246,7 +246,7 @@ class SubmissionHandler extends PKPSubmissionHandler
         Hook::add('Template::SubmissionWizard::Section::Review', function (string $hookName, array $params) {
             $step = $params[0]['step']; /** @var string $step */
             $templateMgr = $params[1]; /** @var TemplateManager $templateMgr */
-            $output = & $params[2]; /** @var string $output */
+            $output = &$params[2]; /** @var string $output */
 
             if ($step === 'editors') {
                 $output .= $templateMgr->fetch('submission/review-license.tpl');

--- a/pages/workflow/WorkflowHandler.php
+++ b/pages/workflow/WorkflowHandler.php
@@ -73,10 +73,14 @@ class WorkflowHandler extends PKPWorkflowHandler
             $submissionContext = Services::get('context')->get($submission->getData('contextId'));
         }
 
-        $locales = $submissionContext->getSupportedSubmissionLocaleNames();
-        $locales = array_map(fn (string $locale, string $name) => ['key' => $locale, 'label' => $name], array_keys($locales), $locales);
-
         $latestPublication = $submission->getLatestPublication();
+
+        $submissionLocale = $submission->getData('locale');
+        $locales = collect($submissionContext->getSupportedSubmissionMetadataLocaleNames() + $submission->getPublicationLanguageNames())
+            ->map(fn (string $name, string $locale) => ['key' => $locale, 'label' => $name])
+            ->sortBy('key')
+            ->values()
+            ->toArray();
 
         $latestPublicationApiUrl = $request->getDispatcher()->url($request, Application::ROUTE_API, $submissionContext->getPath(), 'submissions/' . $submission->getId() . '/publications/' . $latestPublication->getId());
         $temporaryFileApiUrl = $request->getDispatcher()->url($request, Application::ROUTE_API, $submissionContext->getPath(), 'temporaryFiles');
@@ -117,7 +121,7 @@ class WorkflowHandler extends PKPWorkflowHandler
                 }
             }
         }
-        $components[FORM_ISSUE_ENTRY] = $issueEntryForm->getConfig();
+        $components[FORM_ISSUE_ENTRY] = $this->getLocalizedForm($issueEntryForm, $submissionLocale, $locales);
         $components[FORM_ID_RELATION] = $relationForm->getConfig();
 
         $publicationFormIds = $templateMgr->getState('publicationFormIds');

--- a/schemas/galley.json
+++ b/schemas/galley.json
@@ -47,7 +47,7 @@
 			"description": "The primary locale of this galley.",
 			"apiSummary": true,
 			"validation": [
-				"regex:/^([a-z]{2})((_[A-Z]{2})?)(@[a-z]{0,})?$/"
+				"regex:/^([A-Za-z]{2,4})(?<sc>[_-]([A-Za-z]{4,5}|[0-9]{4}))?([_-]([A-Za-z]{2}|[0-9]{3}))?(@[a-z]{2,30}(?&sc)?)?$/"
 			]
 		},
 		"label": {


### PR DESCRIPTION
- In Website Settings > Setup > Languages and in Administration > Hosted Journals > Settings Wizard > Journal Settings > Languages, separate Website Languages and Submission Languages settings. In the website languages are UI and Forms, and in the submission languages are submission and metadata.

- Submission metadata can be edited even if metadata isn't checked in that language in the settings.