### PR TITLE
pkp/pkp-lib#9533 Adds decisions constants migration for OPS 3.4.0

### DIFF
--- a/classes/migration/upgrade/v3_4_0/I7725_DecisionConstantsUpdate.php
+++ b/classes/migration/upgrade/v3_4_0/I7725_DecisionConstantsUpdate.php
@@ -1,0 +1,44 @@
+<?php
+
+/**
+ * @file classes/migration/upgrade/v3_4_0/I7725_DecisionConstantsUpdate.php
+ *
+ * Copyright (c) 2014-2022 Simon Fraser University
+ * Copyright (c) 2000-2022 John Willinsky
+ * Distributed under the GNU GPL v3. For full terms see the file docs/COPYING.
+ *
+ * @class I7725_DecisionConstantsUpdate
+ * @brief Editorial decision constant sync up accross all application
+ *
+ * @see https://github.com/pkp/pkp-lib/issues/7725
+ */
+
+namespace APP\migration\upgrade\v3_4_0;
+
+class I7725_DecisionConstantsUpdate extends \PKP\migration\upgrade\v3_4_0\I7725_DecisionConstantsUpdate
+{
+    /**
+     * Get the decisions constants mappings
+     *
+     */
+    public function getDecisionMappings(): array
+    {
+        return [
+            // \PKP\decision\Decision::INITIAL_DECLINE
+            [
+                'stage_id' => [WORKFLOW_STAGE_ID_PRODUCTION],
+                'current_value' => 9,
+                'updated_value' => 8,
+            ],
+
+            // \PKP\decision\Decision::REVERT_INITIAL_DECLINE
+            [
+                'stage_id' => [WORKFLOW_STAGE_ID_PRODUCTION],
+                'current_value' => 17,
+                'updated_value' => 16
+            ],
+
+
+        ];
+    }
+}

--- a/dbscripts/xml/upgrade.xml
+++ b/dbscripts/xml/upgrade.xml
@@ -72,6 +72,7 @@
 		<migration class="PKP\migration\upgrade\v3_4_0\I8151_ExtendSettingValues"/>
 		<migration class="PKP\migration\upgrade\v3_4_0\I7366_UpdateUserAPIKeySettings"/>
 		<migration class="PKP\migration\upgrade\v3_4_0\I8093_UpdateUserGroupRelationTablesFK"/>
+		<migration class="APP\migration\upgrade\v3_4_0\I7725_DecisionConstantsUpdate"/>
 		<migration class="APP\migration\upgrade\v3_4_0\I7796_UpdateCrossrefSchema"/>
 		<migration class="PKP\migration\upgrade\v3_4_0\I7287_RemoveEmailTemplatesDefault"/>
 		<migration class="PKP\migration\upgrade\v3_4_0\I7874_NotificationMetadataModifiedRemove"/>


### PR DESCRIPTION
This PR is related to [#9533](https://github.com/pkp/pkp-lib/issues/9533)