### PR TITLE
Revert "Correct documentation  template"

### DIFF
--- a/templates/management/context.tpl
+++ b/templates/management/context.tpl
@@ -28,26 +28,26 @@
 
 	<tabs :track-history="true">
 		<tab id="masthead" label="{translate key="manager.setup.masthead"}">
-			{help file="settings/journal-settings" class="pkp_help_tab"}
+			{help file="settings/server-settings" class="pkp_help_tab"}
 			<pkp-form
 				v-bind="components.{$smarty.const.FORM_MASTHEAD}"
 				@set="set"
 			/>
 		</tab>
 		<tab id="contact" label="{translate key="about.contact"}">
-			{help file="settings/journal-settings" section="contact" class="pkp_help_tab"}
+			{help file="settings/server-settings" section="contact" class="pkp_help_tab"}
 			<pkp-form
 				v-bind="components.{$smarty.const.FORM_CONTACT}"
 				@set="set"
 			/>
 		</tab>
 		<tab id="sections" label="{translate key="section.sections"}">
-			{help file="settings/journal-settings" section="sections" class="pkp_help_tab"}
+			{help file="settings/server-settings" section="sections" class="pkp_help_tab"}
 			{capture assign=sectionsGridUrl}{url router=PKPApplication::ROUTE_COMPONENT component="grid.settings.sections.SectionGridHandler" op="fetchGrid" escape=false}{/capture}
 			{load_url_in_div id="sectionsGridContainer" url=$sectionsGridUrl}
 		</tab>
 		<tab id="categories" label="{translate key="grid.category.categories"}">
-			{help file="settings/journal-settings" section="categories" class="pkp_help_tab"}
+			{help file="settings/server-settings" section="categories" class="pkp_help_tab"}
 			{capture assign=categoriesUrl}{url router=PKPApplication::ROUTE_COMPONENT component="grid.settings.category.CategoryCategoryGridHandler" op="fetchGrid" escape=false}{/capture}
 			{load_url_in_div id="categoriesContainer" url=$categoriesUrl}
 		</tab>


### PR DESCRIPTION
#### Revert  server-settings.md to journal-settings.md 

This commit  reverts 157b5a73570b22d00dd9f38d1eeb488b2c54dee9. in   https://github.com/pkp/ops/pull/605

because the better correction was applied in  https://github.com/pkp/ops-user-guide/pull/6 
to reflect context in OPS 

