### PR TITLE
pkp/pkp-lib#6296 Article breadcrumbs - OPS 3.4

### DIFF
--- a/templates/frontend/components/breadcrumbs_preprint.tpl
+++ b/templates/frontend/components/breadcrumbs_preprint.tpl
@@ -13,23 +13,25 @@
  * @uses $currentTitle string The title to use for the current page.
  * @uses $currentTitleKey string Translation key for title of current page.
  *}
-
-<nav class="cmp_breadcrumbs" role="navigation" aria-label="{translate key="navigation.breadcrumbLabel"}">
+{assign var=preprintPath value=$preprint->getBestId()}
+<nav class="cmp_breadcrumbs" aria-label="{translate key="navigation.breadcrumbLabel"}">
 	<ol>
 		<li>
 			<a href="{url page="index" router=PKPApplication::ROUTE_PAGE}">
 				{translate key="common.homepageNavigationLabel"}
 			</a>
-			<span class="separator">{translate key="navigation.breadcrumbSeparator"}</span>
+			<span class="separator" aria-hidden="true">{translate key="navigation.breadcrumbSeparator"}</span>
 		</li>
 		<li class="current" aria-current="page">
-			<span aria-current="page">
+			<a aria-current="page" id="preprint-{$preprint->getId()}" {if $server}href="{url server=$server->getPath() page="preprint" op="view" path=$preprintPath}"{else}href="{url page="preprint" op="view" path=$preprintPath}"{/if}>
+				{assign var=publication value=$preprint->getCurrentPublication()}
+				{$publication->getLocalizedTitle(null, 'html')|strip_unsafe_html}
 				{if $currentTitleKey}
 					{translate key=$currentTitleKey}
 				{else}
-					{$currentTitle|escape}
+					{$publication->getLocalizedSubtitle(null, 'html')|strip_unsafe_html}
 				{/if}
-			</span>
+			</a>
 		</li>
 	</ol>
 </nav>


### PR DESCRIPTION
This PR fixes on OPS 3.4 the issue https://github.com/pkp/pkp-lib/issues/6296 and also implements:

- [x] `aria-current="page"` attribute was not being use on a link to the current page
- [x] Removed `aria-current="page"` attribute from li element, it should to be used on link elements only
- [x] Include a link, using the page title as the label, to the last item on the breadcrumb (article and archive pages)
- [x] Added `aria-hidden="true"` to the breadcrumb separators (they were announced as "slash" by screen readers which is annoying for screen reader users and don't add any information to the context)

Even though showing the full article title might look overwhelming for sighted people, it is helpfull to people that rely on assistive technology like screen readers or screen magnifiers. They can double-check whether they are on the expected page through the breadcrumb interface element.
