### PR TITLE
Fix preprints pagination in archive page

### DIFF
--- a/pages/preprints/PreprintsHandler.php
+++ b/pages/preprints/PreprintsHandler.php
@@ -74,7 +74,7 @@ class PreprintsHandler extends Handler
             ->filterByStatus([Submission::STATUS_PUBLISHED])
             ->orderBy(Collector::ORDERBY_DATE_PUBLISHED);
         $total = $collector->getCount();
-        $publishedSubmissions = $collector->limit($count)->getMany();
+        $publishedSubmissions = $collector->limit($count)->offset($offset)->getMany();
 
         $showingStart = $offset + 1;
         $showingEnd = min($offset + $count, $offset + count($publishedSubmissions));


### PR DESCRIPTION
When using the latest version of OPS 3.4.0, we noticed that the pagination of the preprints on the files page wasn't working properly. Each time we passed the page, the same items from the first page were repeated.

Looking at the code, we realized that the submissions were not being retrieved according to the defined offset. This PR fixes this problem.