### PR TITLE
Fix preprints listing in sections page

### DIFF
--- a/pages/preprints/SectionsHandler.php
+++ b/pages/preprints/SectionsHandler.php
@@ -105,11 +105,6 @@ class SectionsHandler extends Handler
             exit;
         }
 
-        $submissions = [];
-        foreach ($submissions as $submission) {
-            $submissions[] = $submission;
-        }
-
         $showingStart = $collector->offset + 1;
         $showingEnd = min($collector->offset + $collector->count, $collector->offset + count($submissions));
         $nextPage = $total > $showingEnd ? $page + 1 : null;
@@ -120,6 +115,7 @@ class SectionsHandler extends Handler
             'section' => $section,
             'sectionPath' => $sectionPath,
             'preprints' => $submissions,
+            'authorUserGroups' => Repo::userGroup()->getCollector()->filterByRoleIds([\PKP\security\Role::ROLE_ID_AUTHOR])->filterByContextIds([$context->getId()])->getMany()->remember(),
             'showingStart' => $showingStart,
             'showingEnd' => $showingEnd,
             'total' => $total,

--- a/templates/frontend/pages/sections.tpl
+++ b/templates/frontend/pages/sections.tpl
@@ -46,12 +46,12 @@
 
 			{* Pagination *}
 			{if $prevPage > 1}
-				{capture assign="prevUrl"}{url router=PKPApplication::ROUTE_PAGE page="section" op="view" path=$sectionPath|to_array:$prevPage}{/capture}
+				{capture assign="prevUrl"}{url router=PKPApplication::ROUTE_PAGE page="preprints" op="section" path=$sectionPath|to_array:$prevPage}{/capture}
 			{elseif $prevPage === 1}
-				{capture assign="prevUrl"}{url router=PKPApplication::ROUTE_PAGE page="section" op="view" path=$sectionPath}{/capture}
+				{capture assign="prevUrl"}{url router=PKPApplication::ROUTE_PAGE page="preprints" op="section" path=$sectionPath}{/capture}
 			{/if}
 			{if $nextPage}
-				{capture assign="nextUrl"}{url router=PKPApplication::ROUTE_PAGE page="section" op="view" path=$sectionPath|to_array:$nextPage}{/capture}
+				{capture assign="nextUrl"}{url router=PKPApplication::ROUTE_PAGE page="preprints" op="section" path=$sectionPath|to_array:$nextPage}{/capture}
 			{/if}
 			{include
 				file="frontend/components/pagination.tpl"


### PR DESCRIPTION
When using the latest version of OPS 3.4.0, we noticed that the sections page (where preprints in a section are listed) wasn't working properly. It didn't list any preprint, which we found was due to a reset of an array in the handler class.

After fixing it, we noticed the pagination had a problem with the links used to change pages, which we fixed too.