### PR TITLE
pkp/pkp-lib#9937 rename Editorial Team into Editorial History and remove Editorial Team nav menu item

### DIFF
--- a/classes/migration/upgrade/v3_5_0/I9937_EditorialTeamToEditorialHistory.php
+++ b/classes/migration/upgrade/v3_5_0/I9937_EditorialTeamToEditorialHistory.php
@@ -1,0 +1,24 @@
+<?php
+
+/**
+ * @file classes/migration/upgrade/v3_5_0/I9937_EditorialTeamToEditorialHistory.php
+ *
+ * Copyright (c) 2024 Simon Fraser University
+ * Copyright (c) 2024 John Willinsky
+ * Distributed under the GNU GPL v3. For full terms see the file docs/COPYING.
+ *
+ * @class I9937_EditorialTeamToEditorialHistory
+ *
+ * @brief Migrate/rename editorialTeam to editorialHistory context setting and remove Editorial Team navigation menu item.
+ */
+
+namespace APP\migration\upgrade\v3_5_0;
+
+class I9937_EditorialTeamToEditorialHistory extends \PKP\migration\upgrade\v3_5_0\I9937_EditorialTeamToEditorialHistory
+{
+    protected function getContextSettingsTable(): string
+    {
+        return 'server_settings';
+    }
+
+}

--- a/dbscripts/xml/upgrade.xml
+++ b/dbscripts/xml/upgrade.xml
@@ -114,6 +114,7 @@
 		<migration class="PKP\migration\upgrade\v3_5_0\I9566_SessionUpgrade"/>
 		<migration class="PKP\migration\upgrade\v3_5_0\I9809_ReviewCancelDate"/>
 		<migration class="PKP\migration\upgrade\v3_5_0\I9860_EditorialMastheadNavMenuItem"/>
+		<migration class="APP\migration\upgrade\v3_5_0\I9937_EditorialTeamToEditorialHistory"/>
 	</upgrade>
 
 	<!-- update plugin configuration - should be done as the final upgrade task -->

--- a/locale/bg/locale.po
+++ b/locale/bg/locale.po
@@ -215,9 +215,6 @@ msgstr "Контакт"
 msgid "about.aboutContext"
 msgstr "За сървъра"
 
-msgid "about.editorialTeam"
-msgstr "Екип на сървъра за препринти"
-
 msgid "about.submissions"
 msgstr "Изпратени материали"
 

--- a/locale/bg/manager.po
+++ b/locale/bg/manager.po
@@ -215,9 +215,6 @@ msgstr ""
 msgid "manager.setup.contextTitle"
 msgstr "Заглавие на сървъра"
 
-msgid "manager.setup.keyInfo"
-msgstr "Ключова информация"
-
 msgid "manager.setup.lists"
 msgstr "Списъци"
 
@@ -378,11 +375,6 @@ msgid "manager.setup.serverThumbnail.description"
 msgstr ""
 "Малко лого или представяне на сървъра, което може да се използва в списъци "
 "със сървъри."
-
-msgid "manager.setup.keyInfo.description"
-msgstr ""
-"Осигурете описание на вашия сървър и идентифицирайте препринт мениджъра(ите) "
-"и други членове на екипа на сървъра за препринти."
 
 msgid "manager.setup.restrictSiteAccess"
 msgstr ""

--- a/locale/bg/manager.po
+++ b/locale/bg/manager.po
@@ -18,9 +18,6 @@ msgstr "Препринти"
 msgid "manager.language.submissions"
 msgstr "Изпратени материали"
 
-msgid "manager.setup.editorialTeam"
-msgstr "Екип на сървъра за препринти"
-
 msgid "manager.setup.contextAbout"
 msgstr "За сървъра"
 

--- a/locale/ca/locale.po
+++ b/locale/ca/locale.po
@@ -200,9 +200,6 @@ msgstr ""
 msgid "about.aboutContext"
 msgstr ""
 
-msgid "about.editorialTeam"
-msgstr ""
-
 msgid "about.submissions"
 msgstr ""
 

--- a/locale/ca/manager.po
+++ b/locale/ca/manager.po
@@ -212,12 +212,6 @@ msgstr ""
 msgid "manager.setup.contextTitle"
 msgstr ""
 
-msgid "manager.setup.keyInfo"
-msgstr ""
-
-msgid "manager.setup.keyInfo.description"
-msgstr ""
-
 msgid "manager.setup.lists"
 msgstr ""
 

--- a/locale/ca/manager.po
+++ b/locale/ca/manager.po
@@ -104,9 +104,6 @@ msgstr ""
 msgid "manager.setup"
 msgstr ""
 
-msgid "manager.setup.editorialTeam"
-msgstr ""
-
 msgid "manager.setup.useStyleSheet"
 msgstr ""
 

--- a/locale/cs/locale.po
+++ b/locale/cs/locale.po
@@ -187,9 +187,6 @@ msgstr "Kontakt"
 msgid "about.aboutContext"
 msgstr "Podrobnosti o tomto serveru"
 
-msgid "about.editorialTeam"
-msgstr "Tým preprintového serveru"
-
 msgid "about.submissions"
 msgstr "Příspěvky"
 

--- a/locale/cs/manager.po
+++ b/locale/cs/manager.po
@@ -236,9 +236,6 @@ msgstr "Miniatura serveru"
 msgid "manager.setup.contextTitle"
 msgstr "Název serveru"
 
-msgid "manager.setup.keyInfo"
-msgstr "Klíčová informace"
-
 msgid "manager.setup.lists"
 msgstr "Seznamy"
 
@@ -790,11 +787,6 @@ msgid "manager.setup.resetPermissions.confirm"
 msgstr ""
 "Jste si jisti, že si přejete obnovit údaje o oprávněních pro všechny "
 "preprinty? Tuto akci nelze vrátit zpět."
-
-msgid "manager.setup.keyInfo.description"
-msgstr ""
-"Uveďte popis svého serveru a identifikujte správce preprintů a další členy "
-"týmu preprintového serveru."
 
 msgid "manager.setup.numPageLinks.description"
 msgstr ""

--- a/locale/cs/manager.po
+++ b/locale/cs/manager.po
@@ -81,9 +81,6 @@ msgstr "Pravidla sekce"
 msgid "manager.sections.submissionIndexing"
 msgstr "Nebudou zahrnuty do indexace serveru"
 
-msgid "manager.setup.editorialTeam"
-msgstr "Tým preprintového serveru"
-
 msgid "manager.setup.announcements"
 msgstr "Oznámení"
 

--- a/locale/de/locale.po
+++ b/locale/de/locale.po
@@ -220,9 +220,6 @@ msgstr "Kontakt"
 msgid "about.aboutContext"
 msgstr "Über den Server"
 
-msgid "about.editorialTeam"
-msgstr "Preprint-Server-Team"
-
 msgid "about.submissions"
 msgstr "Einreichungen"
 

--- a/locale/de/manager.po
+++ b/locale/de/manager.po
@@ -132,9 +132,6 @@ msgstr ""
 msgid "manager.setup"
 msgstr "Server-Einstellungen"
 
-msgid "manager.setup.editorialTeam"
-msgstr "Preprint-Server-Team"
-
 msgid "manager.setup.useStyleSheet"
 msgstr "Server-Formatvorlage"
 

--- a/locale/de/manager.po
+++ b/locale/de/manager.po
@@ -277,14 +277,6 @@ msgstr ""
 msgid "manager.setup.contextTitle"
 msgstr "Server-Titel"
 
-msgid "manager.setup.keyInfo"
-msgstr "Wichtige Informationen"
-
-msgid "manager.setup.keyInfo.description"
-msgstr ""
-"Geben Sie eine Beschreibung Ihres Servers und nennen Sie den/die Preprint-"
-"Manager und andere Mitglieder des Preprint-Server-Teams."
-
 msgid "manager.setup.lists"
 msgstr "Listen"
 

--- a/locale/en/locale.po
+++ b/locale/en/locale.po
@@ -215,9 +215,6 @@ msgstr "Contact"
 msgid "about.aboutContext"
 msgstr "About the Server"
 
-msgid "about.editorialTeam"
-msgstr "Preprint Server Team"
-
 msgid "about.submissions"
 msgstr "Submissions"
 

--- a/locale/en/manager.po
+++ b/locale/en/manager.po
@@ -125,9 +125,6 @@ msgstr ""
 msgid "manager.setup"
 msgstr "Server Settings"
 
-msgid "manager.setup.editorialTeam"
-msgstr "Preprint Server Team"
-
 msgid "manager.setup.useStyleSheet"
 msgstr "Server style sheet"
 

--- a/locale/en/manager.po
+++ b/locale/en/manager.po
@@ -266,14 +266,6 @@ msgstr ""
 msgid "manager.setup.contextTitle"
 msgstr "Server title"
 
-msgid "manager.setup.keyInfo"
-msgstr "Key Information"
-
-msgid "manager.setup.keyInfo.description"
-msgstr ""
-"Provide a description of your server and identify preprint manager(s) and "
-"other members of the preprint server team."
-
 msgid "manager.setup.lists"
 msgstr "Lists"
 

--- a/locale/en/manager.po
+++ b/locale/en/manager.po
@@ -263,6 +263,9 @@ msgstr ""
 msgid "manager.setup.contextTitle"
 msgstr "Server title"
 
+msgid "manager.setup.editorialMasthead.description"
+msgstr "Please provide the editorial history of your server, including the full name, affiliation, and start and end dates of each editor."
+
 msgid "manager.setup.lists"
 msgstr "Lists"
 

--- a/locale/es/locale.po
+++ b/locale/es/locale.po
@@ -229,9 +229,6 @@ msgid "about.aboutContext"
 msgstr "Sobre el servidor"
 
 #, fuzzy
-msgid "about.editorialTeam"
-msgstr "Equipo editorial"
-
 msgid "about.submissions"
 msgstr "Envíos"
 

--- a/locale/es/manager.po
+++ b/locale/es/manager.po
@@ -138,9 +138,6 @@ msgid "manager.setup"
 msgstr "Configuración del servidor"
 
 #, fuzzy
-msgid "manager.setup.editorialTeam"
-msgstr "Equipo editorial"
-
 msgid "manager.setup.useStyleSheet"
 msgstr "Hoja de estilo del servidor"
 

--- a/locale/es/manager.po
+++ b/locale/es/manager.po
@@ -282,14 +282,6 @@ msgstr ""
 msgid "manager.setup.contextTitle"
 msgstr "Título del servidor"
 
-msgid "manager.setup.keyInfo"
-msgstr "Información clave"
-
-msgid "manager.setup.keyInfo.description"
-msgstr ""
-"Proporcione una breve descripción de su servidor e identifique a los "
-"editores, directores generales y otros miembros de su equipo editorial."
-
 msgid "manager.setup.lists"
 msgstr "Listas"
 

--- a/locale/fi/locale.po
+++ b/locale/fi/locale.po
@@ -217,9 +217,6 @@ msgstr "Yhteystiedot"
 msgid "about.aboutContext"
 msgstr "Tietoa palvelimesta"
 
-msgid "about.editorialTeam"
-msgstr "Palvelimen henkilöstö"
-
 msgid "about.submissions"
 msgstr "Käsikirjoitukset"
 

--- a/locale/fi/manager.po
+++ b/locale/fi/manager.po
@@ -118,9 +118,6 @@ msgstr ""
 msgid "manager.setup"
 msgstr "Palvelimen asetukset"
 
-msgid "manager.setup.editorialTeam"
-msgstr ""
-
 msgid "manager.setup.useStyleSheet"
 msgstr "Palvelimen tyylitiedosto"
 

--- a/locale/fi/manager.po
+++ b/locale/fi/manager.po
@@ -248,12 +248,6 @@ msgstr ""
 msgid "manager.setup.contextTitle"
 msgstr "Palvelimen nimi"
 
-msgid "manager.setup.keyInfo"
-msgstr "Avaintiedot"
-
-msgid "manager.setup.keyInfo.description"
-msgstr ""
-
 msgid "manager.setup.lists"
 msgstr "Listat"
 

--- a/locale/fr_CA/locale.po
+++ b/locale/fr_CA/locale.po
@@ -243,9 +243,6 @@ msgid "about.aboutContext"
 msgstr "À propos du serveur"
 
 #, fuzzy
-msgid "about.editorialTeam"
-msgstr "Équipe éditoriale"
-
 msgid "about.submissions"
 msgstr "Soumissions"
 

--- a/locale/fr_CA/manager.po
+++ b/locale/fr_CA/manager.po
@@ -278,15 +278,6 @@ msgstr ""
 msgid "manager.setup.contextTitle"
 msgstr "Titre du serveur"
 
-msgid "manager.setup.keyInfo"
-msgstr "Renseignements de base"
-
-msgid "manager.setup.keyInfo.description"
-msgstr ""
-"Fournir une brève description de votre serveur et présenter les rédacteurs-"
-"trices, les directeurs-trices ainsi que les autres membres de votre équipe "
-"éditoriale."
-
 msgid "manager.setup.lists"
 msgstr "Listes"
 

--- a/locale/fr_CA/manager.po
+++ b/locale/fr_CA/manager.po
@@ -134,9 +134,6 @@ msgid "manager.setup"
 msgstr "Paramètres du serveur"
 
 #, fuzzy
-msgid "manager.setup.editorialTeam"
-msgstr "Équipe éditoriale"
-
 msgid "manager.setup.useStyleSheet"
 msgstr "Feuille de styles de la série"
 

--- a/locale/mk/locale.po
+++ b/locale/mk/locale.po
@@ -217,9 +217,6 @@ msgstr "Контакт"
 msgid "about.aboutContext"
 msgstr "За серверот"
 
-msgid "about.editorialTeam"
-msgstr "Тим за сервер за печатење"
-
 msgid "about.submissions"
 msgstr "Поднесоци"
 

--- a/locale/mk/manager.po
+++ b/locale/mk/manager.po
@@ -277,14 +277,6 @@ msgstr ""
 msgid "manager.setup.contextTitle"
 msgstr "Наслов на серверот"
 
-msgid "manager.setup.keyInfo"
-msgstr "Клучни информации"
-
-msgid "manager.setup.keyInfo.description"
-msgstr ""
-"Обезбедете опис на вашиот сервер и идентификувајте ги менаџерите за печатење "
-"и другите членови на тимот на сервери за печатење."
-
 msgid "manager.setup.lists"
 msgstr "Списоци"
 

--- a/locale/mk/manager.po
+++ b/locale/mk/manager.po
@@ -132,9 +132,6 @@ msgstr ""
 msgid "manager.setup"
 msgstr "Поставки на серверот"
 
-msgid "manager.setup.editorialTeam"
-msgstr "Тим за сервер за печатење"
-
 msgid "manager.setup.useStyleSheet"
 msgstr "Лист со стил на сервер"
 

--- a/locale/nb/locale.po
+++ b/locale/nb/locale.po
@@ -200,9 +200,6 @@ msgstr ""
 msgid "about.aboutContext"
 msgstr ""
 
-msgid "about.editorialTeam"
-msgstr ""
-
 msgid "about.submissions"
 msgstr ""
 

--- a/locale/nb/manager.po
+++ b/locale/nb/manager.po
@@ -213,12 +213,6 @@ msgstr ""
 msgid "manager.setup.contextTitle"
 msgstr ""
 
-msgid "manager.setup.keyInfo"
-msgstr ""
-
-msgid "manager.setup.keyInfo.description"
-msgstr ""
-
 msgid "manager.setup.lists"
 msgstr ""
 

--- a/locale/nb/manager.po
+++ b/locale/nb/manager.po
@@ -104,9 +104,6 @@ msgstr ""
 msgid "manager.setup"
 msgstr ""
 
-msgid "manager.setup.editorialTeam"
-msgstr ""
-
 msgid "manager.setup.useStyleSheet"
 msgstr ""
 

--- a/locale/pt_BR/locale.po
+++ b/locale/pt_BR/locale.po
@@ -230,9 +230,6 @@ msgid "about.aboutContext"
 msgstr "Sobre o Servidor"
 
 #, fuzzy
-msgid "about.editorialTeam"
-msgstr "Equipe Editorial"
-
 msgid "about.submissions"
 msgstr "Submissões"
 

--- a/locale/pt_BR/manager.po
+++ b/locale/pt_BR/manager.po
@@ -276,14 +276,6 @@ msgstr ""
 msgid "manager.setup.contextTitle"
 msgstr "Título do servidor"
 
-msgid "manager.setup.keyInfo"
-msgstr "Informação chave"
-
-msgid "manager.setup.keyInfo.description"
-msgstr ""
-"Forneça uma breve descrição de seu servidor e identifique os editores, "
-"diretores executivos e outros membros de sua equipe editorial."
-
 msgid "manager.setup.lists"
 msgstr "Listas"
 

--- a/locale/pt_BR/manager.po
+++ b/locale/pt_BR/manager.po
@@ -130,9 +130,6 @@ msgstr ""
 msgid "manager.setup"
 msgstr "Configuração do servidor"
 
-msgid "manager.setup.editorialTeam"
-msgstr "Equipe do Servidor de Preprint"
-
 msgid "manager.setup.useStyleSheet"
 msgstr "Página de estilo do servidor"
 

--- a/locale/tr/locale.po
+++ b/locale/tr/locale.po
@@ -214,9 +214,6 @@ msgstr "İletişim"
 msgid "about.aboutContext"
 msgstr "Sunucu hakkında"
 
-msgid "about.editorialTeam"
-msgstr "Ön Baskı Sunucusu Takımı"
-
 msgid "about.submissions"
 msgstr "Gönderimler"
 

--- a/registry/navigationMenus.xml
+++ b/registry/navigationMenus.xml
@@ -32,7 +32,6 @@
 			<navigationMenuItem title="about.aboutContext" type="NMI_TYPE_ABOUT" />
 			<navigationMenuItem title="about.submissions" type="NMI_TYPE_SUBMISSIONS" />
 			<navigationMenuItem title="common.masthead" type="NMI_TYPE_MASTHEAD" />
-			<navigationMenuItem title="about.editorialTeam" type="NMI_TYPE_EDITORIAL_TEAM" />
 			<navigationMenuItem title="manager.setup.privacyStatement" type="NMI_TYPE_PRIVACY" />
 			<navigationMenuItem title="about.contact" type="NMI_TYPE_CONTACT" />
 		</navigationMenuItem>

--- a/templates/frontend/components/primaryNavMenu.tpl
+++ b/templates/frontend/components/primaryNavMenu.tpl
@@ -34,13 +34,6 @@
 						{translate key="common.editorialMasthead"}
 					</a>
 				</li>
-				{if $currentServer->getLocalizedData('editorialTeam')}
-					<li>
-						<a href="{url router=PKPApplication::ROUTE_PAGE page="about" op="editorialTeam"}">
-							{translate key="about.editorialTeam"}
-						</a>
-					</li>
-				{/if}
 				<li>
 					<a href="{url router=PKPApplication::ROUTE_PAGE page="about" op="submissions"}">
 						{translate key="about.submissions"}


### PR DESCRIPTION
s. https://github.com/pkp/pkp-lib/issues/9937