### PR TITLE
pkp/pkp-lib#10080 fix editorial masthead locale keys and submodule update

### DIFF
--- a/locale/en/manager.po
+++ b/locale/en/manager.po
@@ -266,9 +266,6 @@ msgstr ""
 msgid "manager.setup.contextTitle"
 msgstr "Server title"
 
-msgid "manager.setup.editorialMasthead.description"
-msgstr "Please provide the editorial history of your server, including the full name, affiliation, and start and end dates of each editor."
-
 msgid "manager.setup.lists"
 msgstr "Lists"
 


### PR DESCRIPTION
s. https://github.com/pkp/pkp-lib/issues/10080