### PR TITLE
pkp/pkp-lib#10486 updates `canEditPublication` method call to pass Submission object instead of submission identifier.

### DIFF
--- a/controllers/grid/articleGalleys/ArticleGalleyGridHandler.inc.php
+++ b/controllers/grid/articleGalleys/ArticleGalleyGridHandler.inc.php
@@ -439,7 +439,7 @@ class ArticleGalleyGridHandler extends GridHandler {
 
 		if ($submission->getDateSubmitted() == null) return true;
 
-		if (Services::get('submission')->canEditPublication($submission->getId(), $user->getId())) {
+		if (Services::get('submission')->canEditPublication($submission, $user->getId())) {
 			return true;
 		}
 


### PR DESCRIPTION
With the update of the [canEditPublication](https://github.com/pkp/pkp-lib/blob/d9f0070bf668a4c3b78c7c84689fbab976341db6/classes/services/PKPSubmissionService.inc.php#L795) method in this [PR](https://github.com/pkp/pkp-lib/pull/10693), it will be necessary to update the calls outside `lib-pkp`.