### PR TITLE
[OPS][main] pkp/pkp-lib#12811 Add search landmark to the frontend search form

### DIFF
--- a/templates/frontend/pages/search.tpl
+++ b/templates/frontend/pages/search.tpl
@@ -35,7 +35,7 @@
 	{capture name="searchFormUrl"}{url escape=false}{/capture}
 	{assign var=formUrlParameters value=[]}{* Prevent Smarty warning *}
 	{$smarty.capture.searchFormUrl|parse_url:$smarty.const.PHP_URL_QUERY|default:""|parse_str:$formUrlParameters}
-	<form class="cmp_form" method="get" action="{$smarty.capture.searchFormUrl|strtok:"?"|escape}">
+	<form class="cmp_form" method="get" action="{$smarty.capture.searchFormUrl|strtok:"?"|escape}" role="search">
 		{foreach from=$formUrlParameters key=paramKey item=paramValue}
 			<input type="hidden" name="{$paramKey|escape}" value="{$paramValue|escape}"/>
 		{/foreach}


### PR DESCRIPTION
Addresses pkp/pkp-lib#12811 for OPS.

Matching PR requested by the maintainer: https://github.com/pkp/pkp-lib/issues/12811#issuecomment-5024014482 — israelcefrin noted OJS, OMP, and OPS share the frontend theme and asked for matching PRs. The original issue and fix are on OJS (#5689).

## What changed

`templates/frontend/pages/search.tpl` had **no** landmark role on its search form, so it was not exposed as a landmark at all. This adds `role="search"`, exposing it as a search landmark.

For consistency across the shared theme: OJS is being changed from `role="form"` to `role="search"` (#5689), and **OMP already carries `role="search"` plus an `aria-label`** on its equivalent form, so no OMP PR is needed. This brings OPS into line with both.

One attribute, one line.

## Scope

- The only search `<form>` on this page; the two `role="status"` occurrences are the results live regions, untouched.
- OPS's other search form (`searchForm_archive.tpl`) already has `role="search"` and is not included on this page.
- The header search is an `<a>` link, not a form, and isn't rendered on the search page.

## Testing

Verified by reading the template source. I do not have an OPS instance running, so I have not performed a live screen-reader check.

A companion PR applies this to `stable-3_5_0`.

Refs pkp/pkp-lib#12811

---

Prepared with AI assistance (Claude). I reviewed the template, confirmed the call sites, and checked the change against the issue's requirements.
