### PR TITLE
[stable-3_4_0] pkp/pkp-lib#10486 updates `canEditPublication` method call to pass Submission object instead of submission identifier

### DIFF
--- a/controllers/grid/preprintGalleys/PreprintGalleyGridHandler.php
+++ b/controllers/grid/preprintGalleys/PreprintGalleyGridHandler.php
@@ -497,7 +497,7 @@ class PreprintGalleyGridHandler extends GridHandler
             return true;
         }
 
-        if (Repo::submission()->canEditPublication($submission->getId(), $user->getId())) {
+        if (Repo::submission()->canEditPublication($submission, $user->getId())) {
             return true;
         }
 


### PR DESCRIPTION
Related PR: https://github.com/pkp/pkp-lib/pull/13157 (If approved, they need to be integrated together)