### PR TITLE
e2e hook: pass the branch name so a same-named pkp-e2e companion bran…

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -20,3 +20,7 @@ jobs:
       app: ops
       app_repo: ${{ github.repository }}
       app_ref: ${{ github.sha }}
+      # The PR's branch name. When a pkp-e2e branch of the same name exists
+      # (a "companion" carrying the spec and test updates this change needs),
+      # the suite runs from it instead of pkp-e2e main.
+      companion_branch: ${{ github.head_ref || github.ref_name }}


### PR DESCRIPTION
…ch is used

When a pull request needs spec and test updates in pkp-e2e, those land on a pkp-e2e branch named like the PR's branch. run-app.yml checks for such a branch and runs the suite from it, so the PR's own check can go green before either side merges. Without a companion the hook keeps floating on pkp-e2e main, as before.